### PR TITLE
Typing-inspection 0.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,16 @@ source:
   sha256: 9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - hatchling
     - pip
   run:
-    - python >={{ python_min }}
+    - python
     - typing_extensions >=4.12.0
 
 test:
@@ -30,7 +29,6 @@ test:
     - pip check
   requires:
     - pip
-    - python {{ python_min }}
 
 about:
   summary: Runtime typing introspection tools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,8 @@ about:
     A collection of runtime typing introspection tools, including a
     `typing_inspect` module that provides a consistent interface for
     inspecting types across different Python versions.
-  doc_url: https://typing-inspection.readthedocs.io/en/latest/
-  dev_url:
+  doc_url: https://typing-inspection.readthedocs.io/
+  dev_url: https://github.com/pydantic/typing-inspection
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  skip: true   #[py<39]
 
 requirements:
   host:
@@ -25,16 +26,27 @@ requirements:
 test:
   imports:
     - typing_inspection
+  source_files:
+    - tests/*
   commands:
     - pip check
+    - pytest . -v
   requires:
     - pip
+    - pytest
 
 about:
   summary: Runtime typing introspection tools
   home: https://github.com/pydantic/typing-inspection
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  description: |
+    A collection of runtime typing introspection tools, including a
+    `typing_inspect` module that provides a consistent interface for
+    inspecting types across different Python versions.
+  doc_url: https://typing-inspection.readthedocs.io/en/latest/
+  dev_url:
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
> ## ☆ Typing-inspection 0.4.0 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8070) 
[Upstream](https://github.com/pydantic/typing-inspection)
> 
> ### Changes
> * Removed noarch
> *  Updated `about` section
