### PR TITLE
Update version to 0.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "typing-inspection" %}
-{% set version = "0.4.0" %}
+{% set version = "0.4.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/typing_inspection-{{ version }}.tar.gz
-  sha256: 9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
+  sha256: ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -17,7 +17,7 @@ build:
 requirements:
   host:
     - python
-    - hatchling
+    - hatchling >=1.27.0
     - pip
   run:
     - python
@@ -45,7 +45,7 @@ about:
     A collection of runtime typing introspection tools, including a
     `typing_inspect` module that provides a consistent interface for
     inspecting types across different Python versions.
-  doc_url: https://typing-inspection.readthedocs.io/
+  doc_url: https://typing-inspection.readthedocs.io
   dev_url: https://github.com/pydantic/typing-inspection
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ about:
     A collection of runtime typing introspection tools, including a
     `typing_inspect` module that provides a consistent interface for
     inspecting types across different Python versions.
-  doc_url: https://typing-inspection.readthedocs.io
+  doc_url: https://pydantic.github.io/typing-inspection/0.4
   dev_url: https://github.com/pydantic/typing-inspection
 
 extra:


### PR DESCRIPTION
typing-inspection 0.4.2 

**Destination channel:** main

### Links

- [PKG-10225]
- dev_url:        https://github.com/pydantic/typing-inspection/tree/v0.4.2
- conda_forge:    https://github.com/conda-forge/typing-inspection-feedstock
- pypi:           https://pypi.org/project/typing-inspection/0.4.2
- pypi inspector: https://inspector.pypi.io/project/typing-inspection/0.4.2

### Explanation of changes:

- new version number

[PKG-10225]: https://anaconda.atlassian.net/browse/PKG-10225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ